### PR TITLE
Added flags instead of functions.

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,42 +2,72 @@
 
 The idea is to create something to use to get flags when compiling org-mode source
 
+
+* col/conan-elisp-install
+
+Install Conan packages for `libs', with `flags' specifying the options.
+
+** Usage
+~(col/conan-elisp-install CONAN-LIBS-LIST FLAGS)~
+
+CONAN-LIBS-LIST is a string containing the names and versions of the Conan
+packages to be installed, separated by space. For example: "fmt/8.1.1 zlib/1.2.13".
+
+FLAGS is expected to be one of the symbols 'include, 'libs, 'both, or 'all.
+These options specify which Conan package information to extract:
+
+- 'include extracts the include paths for the Conan packages.
+- 'libs extracts the library paths for the Conan packages.
+- 'both extracts both the include and library paths for the Conan packages.
+- 'all is equivalent to 'both.
+
+The function first extracts the Conan package names and versions from CONAN-LIBS-LIST
+and calls the `col/conan-install` function to install the packages.
+It then extracts the include and/or library paths for the installed packages
+based on the FLAGS option, and sets the corresponding Emacs Lisp variables to
+these paths.
+
+** Example usage
+
+This installs the Conan packages for fmt and zlib with version numbers 8.1.1 and 1.2.13,
+respectively, and extracts the library paths for these packages.
+
 #+begin_src example
-  #+HEADER: :includes <fmt/format.h> :libs (col/conan-elisp-libs "fmt/8.1.1")  :main no :flags (mycompileflags)
+  #+HEADER: :includes <fmt/format.h>  :main no
+  #+HEADER: :libs (col/conan-elisp-install "fmt/8.1.1" 'libs)
+  #+HEADER: :flags (format "-std=c++20 -Wall -Wextra %s " (col/conan-elisp-install "fmt/8.1.1 sml/1.1.6" 'include))
   #+HEADER: :results output raw :exports both  :noweb yes :eval no-export
-   int main(int argc, char *argv[])
-   {
-       fmt::print("{}","hello");
-       return 0;
-   }
+  #+begin_src cpp
+    int main(int argc, char *argv[])
+    {
+        fmt::print("|{}|{}|","hello","conan");
+        return 0;
+    }
+
+  '#+end_src
 #+end_src
 
 
 
-#+HEADER: :exports none
-#+begin_src emacs-lisp :eval  no-export
-  (defun mycompileflags ()
-    "docstring"
-    (format "-std=c++20 -Wall -Wextra %s " (col/conan-elisp-install "fmt/8.1.1 sml/1.1.6") )
-    )
+** Example run
 
-#+end_src
+  #+HEADER: :includes <fmt/format.h> :main no
+  #+HEADER: :libs (col/conan-elisp-install "fmt/8.1.1" 'libs)
+  #+HEADER: :flags (format "-std=c++20 -Wall -Wextra %s " (col/conan-elisp-install "fmt/8.1.1 sml/1.1.6" 'include))
+  #+HEADER: :results output raw :exports both  :noweb yes :eval no-export
+  #+begin_src cpp
+    int main(int argc, char *argv[])
+    {
+        fmt::print("|{}|{}|","hello","conan");
+        return 0;
+    }
 
-#+HEADER: :includes <fmt/format.h> :libs (col/conan-elisp-libs "fmt/8.1.1")  :main no :flags (mycompileflags)
-#+HEADER: :results output raw :exports both  :noweb yes :eval no-export
-#+begin_src cpp
-   int main(int argc, char *argv[])
-   {
-       fmt::print("{}","hello");
-       return 0;
-   }
+  #+end_src
 
-#+end_src
+  #+RESULTS:
+  | hello | conan |
 
+** Note
 
-#+RESULTS:
-hello
-
-
-#+HEADER: :includes <>  :libs -l :main  :flags (format "%s -std=c++ -Wall -Wextra" (org-sbe "fmt_sml.org:conan_install" ))
-#+HEADER: :results output raw :exports results  :noweb yes :eval no-export
+This function assumes that Conan is installed on the system and that the
+necessary Conan packages are available.

--- a/elisp-conan.el
+++ b/elisp-conan.el
@@ -27,6 +27,40 @@
 ;;; Commentary:
 ;;; This can be used in org-source to get the compile flags for source
 ;;; blocks.
+
+;; col/conan-elisp-install
+;;
+;; Install Conan packages for `libs', with `flags' specifying the options.
+;;
+;; Usage:
+;; (col/conan-elisp-install CONAN-LIBS-LIST FLAGS)
+;;
+;; CONAN-LIBS-LIST is a string containing the names and versions of the Conan
+;; packages to be installed, separated by space. For example: "fmt/8.1.1 zlib/1.2.13".
+;;
+;; FLAGS is expected to be one of the symbols 'include, 'libs, 'both, or 'all.
+;; These options specify which Conan package information to extract:
+;;
+;; - 'include extracts the include paths for the Conan packages.
+;; - 'libs extracts the library paths for the Conan packages.
+;; - 'both extracts both the include and library paths for the Conan packages.
+;; - 'all is equivalent to 'both.
+;;
+;; The function first extracts the Conan package names and versions from CONAN-LIBS-LIST
+;; and calls the `col/conan-install` function to install the packages.
+;; It then extracts the include and/or library paths for the installed packages
+;; based on the FLAGS option, and sets the corresponding Emacs Lisp variables to
+;; these paths.
+;;
+;; Example usage:
+;; (col/conan-elisp-install "fmt/8.1.1 zlib/1.2.13" 'libs)
+;;
+;; This installs the Conan packages for fmt and zlib with version numbers 8.1.1 and 1.2.13,
+;; respectively, and extracts the library paths for these packages.
+;;
+;; Note: This function assumes that Conan is installed on the system and that the
+;; necessary Conan packages are available.
+
 ;; todo alot! Buts its a start..
 
 ;;; Code:
@@ -84,9 +118,13 @@
 
 (defun col/conan-install ( libs generators)
   "Creates a directory structure and adds a conanfile.txt and runs the conan install."
-  (let ((conan-file  (col/make-buffer  libs  generators)))
+  (let (
+        (current-dir default-directory)
+        (conan-file  (col/make-buffer  libs  generators)))
+
     (cd (f-dirname conan-file))
     (shell-command-to-string conan-install-cmd )
+    (cd current-dir)
     conan-file
     ))
 
@@ -133,38 +171,39 @@
 ;(concat (col/conan-get-include '("fmt/8.1.1" "sml/1.1.4")) "apa")
 
 
-(defun col/conan-elisp-install (conan-libs-list)
-  "Will setup conan and install libraries, returns the compile flags (include and libs)"
-  (interactive "sEnter a space sepparated list of conan packages: ")
-  (let* (
-         (current-dir default-directory)
-         (conan-libs (s-split " " conan-libs-list 'omit-nulls))
-         (temp-conan-file (col/conan-install conan-libs '("PkgConfigDeps")))
-         (compile-flags (col/conan-get-compile-flags conan-libs (f-dirname temp-conan-file)))
-         )
-    (message " conan libs %s \ntemp-conan-dir: %s flags %s" conan-libs temp-conan-file compile-flags )
-    (cd current-dir)
-
-    compile-flags
+(defun col/check-options (opts )
+  "Takes a single argument opts which is expected to be one of the
+symbols include, libs, both, or all. and returns a function pointer
+to retrieve the compile flags (based on argument)."
+  (cl-case opts
+    (include #'col/conan-get-include)
+    (libs #'col/conan-get-libs )
+    (both #'col/conan-get-compile-flags)
+    (all #'col/conan-get-compile-flags)
     ))
 
 
-(defun col/conan-elisp-libs (conan-libs-list)
-  "Will setup conan and install libraries, returns the compile flags (include and libs)"
-  (interactive "sEnter a space sepparated list of conan packages: ")
+
+(defun col/conan-elisp-install (conan-libs-list flags)
+  "Install Conan packages for `libs', with `flags' specifying the options.
+- libs should be in the format \"fmt/8.1.1 zlib/1.2.13\"
+- flags could be either 'include, 'libs or 'all or 'both,
+the )
+"
   (let* (
          (current-dir default-directory)
+         (compile-fn (col/check-options flags))
          (conan-libs (s-split " " conan-libs-list 'omit-nulls))
          (temp-conan-file (col/conan-install conan-libs '("PkgConfigDeps")))
-         (compile-flags (col/conan-get-libs conan-libs (f-dirname temp-conan-file)))
-         )
-    (message " conan libs %s \ntemp-conan-dir: %s flags %s" conan-libs temp-conan-file compile-flags )
-    (cd current-dir)
+         (conan-dir (f-dirname temp-conan-file))
 
-    compile-flags
-    ))
+        )
+    ;;(message "opt %s libs: %s" opt  conan-libs)
+    (cd current-dir)
+    (funcall compile-fn conan-libs conan-dir)
+    )
+  )
 
 ;; Examples
-;; (col/conan-elisp-install "fmt/8.1.1 sml/1.1.6 zlib/1.2.13")
-;; (col/conan-elisp-libs "fmt/8.1.1 sml/1.1.6 zlib/1.2.13")
+;; (col/conan-elisp-install "fmt/8.1.1 sml/1.1.6 zlib/1.2.13" 'all)
 ;;; conan-elisp.el ends here


### PR DESCRIPTION
Add README documentation for col/conan-elisp-install

The README.org file has been updated to contain a detailed explanation of the `col/conan-elisp-install` function, which is used to install Conan packages and extract library and include paths for these packages. The function now supports options to extract either the library paths, include paths, or both paths.

Example usage and example run sections have also been added to README.org to demonstrate how to use `col/conan-elisp-install`.

The `elisp-conan.el` file has been modified to support the new options for `col/conan-elisp-install`, which include `include`, `libs`, `both`, and `all`.